### PR TITLE
Infinito

### DIFF
--- a/api/controllers/audioController.ts
+++ b/api/controllers/audioController.ts
@@ -397,6 +397,20 @@ export async function getMostListenedAudios(req: Request, res: Response) {
     }
 }
 
+
+export async function getNRandomAudios(req: Request, res: Response) {
+    try {
+        const n = Number(req.params.nAudios);
+        if (!n || n <= 0) {
+            return res.status(400).send('Bad Parameters, nAudios must be a positive number');
+        }
+        const audios = await audioDatabase.getNRandomAudios(n);
+        res.json(audios);
+    } catch (error) {
+        res.status(500).send(error);
+    }
+}
+
 function deleteFile(filePath: string) {
     try {
         fs.unlinkSync(filePath); // Borra el archivo del servidor
@@ -418,3 +432,5 @@ async function isOwnerOrAdmin(req: Request){
         }
         return true;
 }
+
+

--- a/api/controllers/etiquetasController.ts
+++ b/api/controllers/etiquetasController.ts
@@ -83,6 +83,9 @@ export const tagsNUltimasEscuchas = async (req: Request, res: Response) => {
   try {
     const idUsuario = Number(req.auth?.idUsuario);
     const nAudios = Number(req.params.numEscuchas);
+    
+    console.log("idUsuario: ", idUsuario);
+    console.log("nAudios: ", nAudios);
 
     if (!nAudios || nAudios <= 0) {
       return res.status(400).json({ message: 'Bad request. numEscuchas must be a positive number' });
@@ -107,6 +110,10 @@ export const getNAudiosByTags = async (req: Request, res: Response) => {
     const nAudiosToGetTagsFrom = Number(req.params.nAudiosToGetTagsFrom);
     const nAudios = Number(req.params.nAudiosResult);
 
+    console.log("idUsuario: ", idUsuario);
+    console.log("nAudiosToGetTagsFrom: ", nAudiosToGetTagsFrom);
+    console.log("nAudios: ", nAudios);
+
     if (!nAudiosToGetTagsFrom || nAudiosToGetTagsFrom <= 0) {
       return res.status(400).json({ message: 'Bad request. numEscuchas must be a positive number' });
     }
@@ -115,6 +122,7 @@ export const getNAudiosByTags = async (req: Request, res: Response) => {
     }
 
     const tags = await etiquetasDbJs.tagsNLastListened(idUsuario, nAudiosToGetTagsFrom);
+    console.log(tags);
     const audios = await etiquetasDbJs.getNAudiosByTags(nAudios, tags);
 
     res.json(audios);

--- a/api/routes/audioRoutes.ts
+++ b/api/routes/audioRoutes.ts
@@ -448,7 +448,37 @@ router.put('/update/:idaudio', auth.authenticate,audioController.deleteTmpFiles,
 router.post('/stats/:idaudio', auth.authenticate, audioController.verifyAudio, audioController.audioStats);
 
 
-
-
+/**
+ * @swagger
+ * /random/{nAudios}:
+ *   post:
+ *     summary:Devuelve una lista con nAudios audios aleatorios de la base de datos
+ *     tags: [Audio]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: nAudios
+ *         required: true
+ *         description: Número de audios a devolver
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Audios devueltos correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Audio'
+ *
+ *       400:
+ *         description: No se ha recibido el número de audios a devolver
+ *       403:
+ *         description: No se tiene permiso para acceder a este recurso
+ *       500:
+ *         description: Error interno del servidor
+ */
 router.get('/random/:nAudios', auth.authenticate, audioController.getNRandomAudios);
 export default router;

--- a/api/routes/audioRoutes.ts
+++ b/api/routes/audioRoutes.ts
@@ -450,9 +450,9 @@ router.post('/stats/:idaudio', auth.authenticate, audioController.verifyAudio, a
 
 /**
  * @swagger
- * /random/{nAudios}:
- *   post:
- *     summary:Devuelve una lista con nAudios audios aleatorios de la base de datos
+ * /audio/random/{nAudios}:
+ *   get:
+ *     summary: Devuelve una lista con nAudios audios aleatorios de la base de datos
  *     tags: [Audio]
  *     security:
  *       - bearerAuth: []
@@ -472,13 +472,12 @@ router.post('/stats/:idaudio', auth.authenticate, audioController.verifyAudio, a
  *               type: array
  *               items:
  *                 $ref: '#/components/schemas/Audio'
- *
  *       400:
  *         description: No se ha recibido el número de audios a devolver
  *       403:
  *         description: No se tiene permiso para acceder a este recurso
  *       500:
- *         description: Error interno del servidor
+ *           description: Error interno del servidor
  */
 router.get('/random/:nAudios', auth.authenticate, audioController.getNRandomAudios);
 export default router;

--- a/api/routes/audioRoutes.ts
+++ b/api/routes/audioRoutes.ts
@@ -450,5 +450,5 @@ router.post('/stats/:idaudio', auth.authenticate, audioController.verifyAudio, a
 
 
 
-
+router.get('/random/:nAudios', auth.authenticate, audioController.getNRandomAudios);
 export default router;

--- a/api/routes/etiquetasRoutes.ts
+++ b/api/routes/etiquetasRoutes.ts
@@ -201,8 +201,8 @@ router.post(
  * @swagger
  * /etiquetas/infinite/{nAudiosToGetTagsFrom}/{nAudiosResult}:
  *   get:
- *     summary: Obtiene las etiquetas de las últimas n audios escuchados
- *     description: Obtiene las etiquetas de las últimas n audios escuchados por el usuario.
+ *     summary: Obtiene nAudiosResult audios que contengan etiquetas de las últimas nAudiosToGetTagsFrom escuchas
+ *     description: Obtienes nAudiosResult audios que contengan etiquetas de las últimas nAudiosToGetTagsFrom escuchas del usuario.
  *     tags: [Etiquetas]
  *     security:
  *       - bearerAuth: []
@@ -240,8 +240,8 @@ router.get("/infinite/:nAudiosToGetTagsFrom/:nAudiosResult", auth.authenticate, 
  * @swagger
  * /etiquetas/tagsnlastlistened/{numEscuchas}:
  *   get:
- *     summary: Obtiene las etiquetas de las últimas n audios escuchados
- *     description: Obtiene las etiquetas de las últimas n audios escuchados por el usuario.
+ *     summary: Obtiene las etiquetas de los últimos n audios escuchados
+ *     description: Obtiene las etiquetas de los últimos n audios escuchados por el usuario.
  *     tags: [Etiquetas]
  *     security:
  *       - bearerAuth: []

--- a/api/routes/etiquetasRoutes.ts
+++ b/api/routes/etiquetasRoutes.ts
@@ -236,5 +236,45 @@ router.post(
 router.get("/infinite/:nAudiosToGetTagsFrom/:nAudiosResult", auth.authenticate, validate, etiquetas.getNAudiosByTags);
 
 
-router.get("/tagsNLastListened/:numEscuchas", auth.authenticate, validate, etiquetas.tagsNUltimasEscuchas);
+/**
+ * @swagger
+ * /etiquetas/tagsnlastlistened/{numEscuchas}:
+ *   get:
+ *     summary: Obtiene las etiquetas de las últimas n audios escuchados
+ *     description: Obtiene las etiquetas de las últimas n audios escuchados por el usuario.
+ *     tags: [Etiquetas]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: numEscuchas
+ *         required: true
+ *         description: Número de audios de los que se obtendrán las etiquetas.
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       '200':
+ *         description: Éxito, devuelve las etiquetas de los últimos n audios escuchados.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: string
+ *       '400':
+ *         description: Solicitud incorrecta, el número de audios a obtener debe ser un número positivo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Bad request. numEscuchas must be a positive number"
+ *       '401':
+ *         description: No autorizado, el usuario no tiene permiso para acceder.
+ *       '500':
+ *         description: Error interno del servidor.
+ */
+router.get("/tagsnlastlistened/:numEscuchas", auth.authenticate, validate, etiquetas.tagsNUltimasEscuchas);
 export default router;

--- a/api/routes/etiquetasRoutes.ts
+++ b/api/routes/etiquetasRoutes.ts
@@ -233,6 +233,8 @@ router.post(
  *       '500':
  *         description: Error interno del servidor.
  */
-router.get("/infinite/:nAudiosToGetTagsFrom/:nAudiosResult", auth.authenticate, validate, etiquetas.tagsNUltimasEscuchas);
+router.get("/infinite/:nAudiosToGetTagsFrom/:nAudiosResult", auth.authenticate, validate, etiquetas.getNAudiosByTags);
 
+
+router.get("/tagsNLastListened/:numEscuchas", auth.authenticate, validate, etiquetas.tagsNUltimasEscuchas);
 export default router;

--- a/api/routes/etiquetasRoutes.ts
+++ b/api/routes/etiquetasRoutes.ts
@@ -195,4 +195,44 @@ router.post(
   etiquetas.tagsOfAudios,
 );
 
+
+
+/**
+ * @swagger
+ * /etiquetas/infinite/{nAudiosToGetTagsFrom}/{nAudiosResult}:
+ *   get:
+ *     summary: Obtiene las etiquetas de las últimas n audios escuchados
+ *     description: Obtiene las etiquetas de las últimas n audios escuchados por el usuario.
+ *     tags: [Etiquetas]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: nAudiosToGetTagsFrom
+ *         required: true
+ *         description: Número de audios de los que se obtendrán las etiquetas.
+ *         schema:
+ *           type: integer
+ *       - in: path
+ *         name: nAudiosResult
+ *         required: true
+ *         description: Número de audios que se devolverán.
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       '200':
+ *         description: Éxito, devuelve las etiquetas de los últimos n audios escuchados.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Audio'
+ *       '401':
+ *         description: No autorizado, el usuario no tiene permiso para acceder.
+ *       '500':
+ *         description: Error interno del servidor.
+ */
+router.get("/infinite/:nAudiosToGetTagsFrom/:nAudiosResult", auth.authenticate, validate, etiquetas.tagsNUltimasEscuchas);
+
 export default router;

--- a/db/audioDb.ts
+++ b/db/audioDb.ts
@@ -273,3 +273,23 @@ export async function getMostListenedAudios() {
   
     return { audio, podcast };
   }
+
+
+  export async function getNRandomAudios(n: number) {
+    // To ensure that the same audio is not selected twice, we first get the total number of audios
+    const totalAudios = await prisma.audio.count();
+    const randomSeed = Math.floor(Math.random() * totalAudios);
+
+    if (n > totalAudios) {
+      throw new Error('Not enough audios in the database');
+    }
+
+    const audios = await prisma.audio.findMany({
+      skip: randomSeed,
+      take: n,
+    });
+
+
+    return audios;
+
+  }

--- a/db/audioDb.ts
+++ b/db/audioDb.ts
@@ -286,6 +286,14 @@ export async function getMostListenedAudios() {
     const audios = await prisma.audio.findMany({
       skip: randomSeed,
       take: n,
+      include: {
+        Artistas: {
+          select: {
+            idUsuario: true,
+            nombreUsuario: true,
+          }
+        }
+      },
     });
 
 

--- a/db/audioDb.ts
+++ b/db/audioDb.ts
@@ -276,7 +276,6 @@ export async function getMostListenedAudios() {
 
 
   export async function getNRandomAudios(n: number) {
-    // To ensure that the same audio is not selected twice, we first get the total number of audios
     const totalAudios = await prisma.audio.count();
     const randomSeed = Math.floor(Math.random() * totalAudios);
 

--- a/db/etiquetasDb.ts
+++ b/db/etiquetasDb.ts
@@ -173,6 +173,8 @@ export async function existsTag (id: number): Promise<boolean> {
 
 // Devuelve la lista con los nombres de las etiquetas de las últimas nEscuchas del usuario
 export async function tagsNLastListened(userId: number, nEscuchas: number) {
+  console.log("userId: ", userId);
+  console.log("nEscuchas: ", nEscuchas);
   const escuchas = await prisma.escucha.findMany({
     where: {
       idUsuario: userId,

--- a/db/etiquetasDb.ts
+++ b/db/etiquetasDb.ts
@@ -170,3 +170,62 @@ export async function existsTag (id: number): Promise<boolean> {
   }
 }
 
+
+// Devuelve la lista con los nombres de las etiquetas de las últimas nEscuchas del usuario
+export async function tagsNLastListened(userId: number, nEscuchas: number) {
+  const escuchas = await prisma.escucha.findMany({
+    where: {
+      idUsuario: userId,
+    },
+    orderBy: {
+      fecha: 'desc',
+    },
+    take: nEscuchas,
+    include: {
+      Audio: {
+        include: {
+          EtiquetasCancion: true,
+          EtiquetasPodcast: true,
+        },
+      },
+    },
+  });
+  //  escuchas = {idEscucha, fecha, Audio: {idAudio, nombre, EtiquetasCancion: [{idEtiqueta, nombre}], EtiquetasPodcast: [{idEtiqueta, nombre}]}
+  const tags = escuchas.flatMap(escucha => {
+    const etiquetas = escucha.Audio.EtiquetasCancion || escucha.Audio.EtiquetasPodcast;
+    return etiquetas.map(etiqueta => etiqueta.nombre);
+  });
+
+  return tags;
+}
+
+// Devuelve numAudios audios aleatorios que contengan las etiquetas
+export async function getNAudiosByTags(numAudios: number, tags: string[]) {
+  const audios = await prisma.audio.findMany({
+    where: {
+      OR: [
+        {
+          EtiquetasCancion: {
+            some: {
+              nombre: {
+                in: tags,
+              },
+            },
+          },
+        },
+        {
+          EtiquetasPodcast: {
+            some: {
+              nombre: {
+                in: tags,
+              },
+            },
+          },
+        },
+      ],
+    },
+    take: numAudios,
+  });
+
+  return audios;
+}


### PR DESCRIPTION
Añadido endpoint /audio/random/:nAudios que devuelve nAudios aleatorios (aunque consecutivos en la base de datos)

Añadidos endpoints /etiquetas/infinite/:nAudiosToGetTagsFrom/:nAudiosResult y /etiquetas/tagsnlastlistened/:numEscuchas pero tardan mucho en realizar la consulta por lo que no son utilizables actualmente